### PR TITLE
Add padding to audio visualizer in journal item

### DIFF
--- a/lib/presentation/screens/journal/journal_body.dart
+++ b/lib/presentation/screens/journal/journal_body.dart
@@ -337,7 +337,7 @@ class _RowWithEditAndDeleteButton extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.center,
       children: [
         startWidget,
-        middleWidget ?? SizedBox(),
+        Expanded(child: middleWidget ?? SizedBox()),
         Row(
           mainAxisSize: MainAxisSize.min,
           children: [

--- a/lib/presentation/screens/journal/journal_item_audio_player_body.dart
+++ b/lib/presentation/screens/journal/journal_item_audio_player_body.dart
@@ -72,6 +72,9 @@ class JournalItemAudioPlayerBody extends StatelessWidget {
                 ],
               ),
             ),
+            SizedBox(
+              width: 16,
+            )
           ],
         ),
       ],


### PR DESCRIPTION
Add a padding in audio visualizer to align with other widgets.
<img width="1206" height="2622" alt="simulator_screenshot_5D7F52CE-6C36-419D-B68B-26E533401B60" src="https://github.com/user-attachments/assets/4fe7740f-79ef-46b3-a43b-3c4338b4cb26" />
